### PR TITLE
Remove UiAutomationMcp.Tests project from solution

### DIFF
--- a/UIAutomationMCP.sln
+++ b/UIAutomationMCP.sln
@@ -15,8 +15,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UIAutomationMCP.Subprocess.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UIAutomationMCP.Models", "UIAutomationMCP.Models\UIAutomationMCP.Models.csproj", "{34567890-3456-3456-3456-345678901234}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UiAutomationMcp.Tests", "UiAutomationMcp.Tests\UiAutomationMcp.Tests.csproj", "{45678901-4567-4567-4567-456789012345}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -99,18 +97,6 @@ Global
 		{34567890-3456-3456-3456-345678901234}.Release|x64.Build.0 = Release|Any CPU
 		{34567890-3456-3456-3456-345678901234}.Release|x86.ActiveCfg = Release|Any CPU
 		{34567890-3456-3456-3456-345678901234}.Release|x86.Build.0 = Release|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Debug|x64.Build.0 = Debug|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Debug|x86.Build.0 = Debug|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Release|Any CPU.Build.0 = Release|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Release|x64.ActiveCfg = Release|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Release|x64.Build.0 = Release|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Release|x86.ActiveCfg = Release|Any CPU
-		{45678901-4567-4567-4567-456789012345}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Eliminate the UiAutomationMcp.Tests project from the solution to streamline the project structure.