### PR TITLE
fix: implement searchText/fuzzyMatch filtering in SearchElements

### DIFF
--- a/UIAutomationMCP.Subprocess.Worker/Helpers/SearchTextMatcher.cs
+++ b/UIAutomationMCP.Subprocess.Worker/Helpers/SearchTextMatcher.cs
@@ -1,0 +1,77 @@
+using System.Text;
+
+namespace UIAutomationMCP.Subprocess.Worker.Helpers
+{
+    /// <summary>
+    /// Provides cross-property text matching for element searches.
+    /// UI Automation's PropertyCondition only supports exact matches, so the SearchElements
+    /// substring/fuzzy filtering must be performed in-process against the found elements.
+    /// </summary>
+    public static class SearchTextMatcher
+    {
+        /// <summary>
+        /// Returns true if <paramref name="candidate"/> matches <paramref name="searchText"/>.
+        /// When <paramref name="fuzzyMatch"/> is false, performs a case-insensitive substring match.
+        /// When true, normalizes both sides (dropping whitespace and non-alphanumeric characters and
+        /// lowercasing) before performing the substring match, so a query like "RichEditBox" also
+        /// matches "Rich Edit Box", "rich-edit-box", "rich_edit_box", etc.
+        /// </summary>
+        public static bool IsMatch(string? candidate, string? searchText, bool fuzzyMatch)
+        {
+            // An empty search text imposes no filter.
+            if (string.IsNullOrEmpty(searchText))
+                return true;
+
+            if (string.IsNullOrEmpty(candidate))
+                return false;
+
+            if (!fuzzyMatch)
+                return candidate.Contains(searchText, StringComparison.OrdinalIgnoreCase);
+
+            var normalizedSearch = Normalize(searchText);
+
+            // If the search text has no alphanumeric characters, fall back to a plain
+            // case-insensitive substring match rather than matching everything.
+            if (normalizedSearch.Length == 0)
+                return candidate.Contains(searchText, StringComparison.OrdinalIgnoreCase);
+
+            return Normalize(candidate).Contains(normalizedSearch, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Returns true if any of the supplied candidate values matches the search text.
+        /// Used to run the cross-property (Name / AutomationId / ClassName) search in one call.
+        /// </summary>
+        public static bool IsMatchAny(string? searchText, bool fuzzyMatch, params string?[] candidates)
+        {
+            if (string.IsNullOrEmpty(searchText))
+                return true;
+
+            if (candidates == null)
+                return false;
+
+            foreach (var candidate in candidates)
+            {
+                if (!string.IsNullOrEmpty(candidate) && IsMatch(candidate, searchText, fuzzyMatch))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Normalizes a string for fuzzy matching by lowercasing and dropping any character
+        /// that is not a letter or digit.
+        /// </summary>
+        private static string Normalize(string value)
+        {
+            var builder = new StringBuilder(value.Length);
+            foreach (var c in value)
+            {
+                if (char.IsLetterOrDigit(c))
+                    builder.Append(char.ToLowerInvariant(c));
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/UIAutomationMCP.Subprocess.Worker/Operations/ElementSearch/SearchElementsOperation.cs
+++ b/UIAutomationMCP.Subprocess.Worker/Operations/ElementSearch/SearchElementsOperation.cs
@@ -122,6 +122,20 @@ namespace UIAutomationMCP.Subprocess.Worker.Operations.ElementSearch
                 bool useCacheOptimization = _options.Value.Performance.EnableCacheOptimization;
                 var foundElementsList = FindElementsWithOptimalMethod(searchCriteria, useCacheOptimization);
 
+                // Cross-property searchText / fuzzyMatch filtering.
+                // UIA PropertyCondition only supports exact matches, so substring/fuzzy filtering
+                // is applied here against the found elements. This runs before sorting and the
+                // MaxResults/totalFound calculation so the metadata counts reflect the filtered set.
+                if (!string.IsNullOrEmpty(request.SearchText))
+                {
+                    var beforeFilter = foundElementsList.Count;
+                    foundElementsList = FilterBySearchText(
+                        foundElementsList, request.SearchText!, request.FuzzyMatch, useCacheOptimization);
+                    _logger?.LogDebug(
+                        "SearchText filter '{SearchText}' (fuzzy={Fuzzy}) matched {Matched} of {Total} elements",
+                        request.SearchText, request.FuzzyMatch, foundElementsList.Count, beforeFilter);
+                }
+
                 // Apply basic filtering and sorting
                 if (!string.IsNullOrEmpty(request.SortBy))
                 {
@@ -344,6 +358,61 @@ namespace UIAutomationMCP.Subprocess.Worker.Operations.ElementSearch
                 return props.BoundingRectangle.Y;
             }
             catch { return 0; }
+        }
+
+        /// <summary>
+        /// Filters elements by the cross-property searchText: keeps an element when its Name,
+        /// AutomationId, or ClassName matches the search text (case-insensitive substring, or
+        /// normalized fuzzy match when <paramref name="fuzzyMatch"/> is true). UIA cannot express
+        /// substring conditions, so this is applied in-process to the already-found elements.
+        /// </summary>
+        private List<AutomationElement> FilterBySearchText(
+            List<AutomationElement> elements, string searchText, bool fuzzyMatch, bool useCached)
+        {
+            var result = new List<AutomationElement>(elements.Count);
+            foreach (var element in elements)
+            {
+                var name = GetSearchableProperty(element, AutomationElement.NameProperty, useCached);
+                var automationId = GetSearchableProperty(element, AutomationElement.AutomationIdProperty, useCached);
+                var className = GetSearchableProperty(element, AutomationElement.ClassNameProperty, useCached);
+
+                if (SearchTextMatcher.IsMatchAny(searchText, fuzzyMatch, name, automationId, className))
+                {
+                    result.Add(element);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Reads a string property for searchText matching. Prefers the cached value when cache
+        /// optimization is active, falling back to the current value when the property was not
+        /// cached for this element (e.g. elements returned by ListSearchOptimizer, which runs
+        /// outside the CacheRequest scope).
+        /// </summary>
+        private static string GetSearchableProperty(AutomationElement element, AutomationProperty property, bool useCached)
+        {
+            if (useCached)
+            {
+                try
+                {
+                    if (element.GetCachedPropertyValue(property) is string cached)
+                        return cached;
+                }
+                catch
+                {
+                    // Property not cached for this element; fall through to the current value.
+                }
+            }
+
+            try
+            {
+                return element.GetCurrentPropertyValue(property) as string ?? string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
         }
 
 

--- a/UiAutomationMcp.Tests/E2E/WinUI3GalleryComprehensiveTests.cs
+++ b/UiAutomationMcp.Tests/E2E/WinUI3GalleryComprehensiveTests.cs
@@ -51,6 +51,63 @@ namespace UIAutomationMCP.Tests.E2E
         }
 
         [Fact]
+        public async Task Test_03b_SearchElements_SearchText_ActuallyFilters()
+        {
+            Output.WriteLine("=== Testing SearchElements searchText actually filters results ===");
+
+            // Baseline: an unfiltered search returns the (capped) full element tree.
+            var allJson = (await Tools.SearchElements(maxResults: 1000)).ToJsonElement();
+            int totalAll = GetTotalFound(allJson);
+            Output.WriteLine($"Unfiltered totalFound = {totalAll}");
+            Assert.True(totalAll > 0, "Baseline search should find elements");
+
+            // 1) A token that cannot occur must yield zero results.
+            //    Before the fix, searchText was ignored and this returned the whole tree.
+            const string nonsense = "ZZ_NoSuchElement_QWERTY_123";
+            var nonsenseJson = (await Tools.SearchElements(searchText: nonsense, maxResults: 1000)).ToJsonElement();
+            int totalNonsense = GetTotalFound(nonsenseJson);
+            var nonsenseElements = GetElements(nonsenseJson);
+            Output.WriteLine($"Nonsense searchText totalFound = {totalNonsense}, returned = {nonsenseElements.Count}");
+            Assert.Equal(0, totalNonsense);
+            Assert.Empty(nonsenseElements);
+
+            // 2) A real token taken from an actual element must return only matching elements.
+            var allElements = GetElements(allJson);
+            var token = allElements
+                .Select(e => GetStr(e, "name"))
+                .FirstOrDefault(n => n.Length >= 4 && n.All(c => !char.IsWhiteSpace(c)));
+            if (string.IsNullOrEmpty(token))
+            {
+                token = "Home"; // Fallback to a common navigation item name.
+            }
+
+            Output.WriteLine($"Filtering by real token: '{token}'");
+            var filteredJson = (await Tools.SearchElements(searchText: token, maxResults: 1000)).ToJsonElement();
+            var filteredElements = GetElements(filteredJson);
+            int totalFiltered = GetTotalFound(filteredJson);
+            Output.WriteLine($"Filtered totalFound = {totalFiltered}, returned = {filteredElements.Count}");
+
+            Assert.True(totalFiltered > 0, $"searchText '{token}' should match at least one element");
+            Assert.True(totalFiltered <= totalAll, "Filtered result cannot exceed the unfiltered result");
+
+            foreach (var el in filteredElements)
+            {
+                var name = GetStr(el, "name");
+                var automationId = GetStr(el, "automationId");
+                var className = GetStr(el, "className");
+
+                bool matches =
+                    name.Contains(token, StringComparison.OrdinalIgnoreCase) ||
+                    automationId.Contains(token, StringComparison.OrdinalIgnoreCase) ||
+                    className.Contains(token, StringComparison.OrdinalIgnoreCase);
+
+                Assert.True(matches,
+                    $"Returned element does not contain searchText '{token}': " +
+                    $"name='{name}', automationId='{automationId}', className='{className}'");
+            }
+        }
+
+        [Fact]
         public async Task Test_04_GetElementTree_ShouldShowHierarchy()
         {
             Output.WriteLine("=== Testing GetElementTree ===");
@@ -1026,6 +1083,47 @@ namespace UIAutomationMCP.Tests.E2E
                 Output.WriteLine($"{operation} result serialization failed: {ex.Message}");
                 Output.WriteLine($"{operation} result type: {result?.GetType().Name ?? "null"}");
             }
+        }
+
+        /// <summary>
+        /// Extracts the data.elements array from a serialized SearchElements response.
+        /// </summary>
+        private static List<JsonElement> GetElements(JsonElement response)
+        {
+            if (response.TryGetPropertyCI("data", out var data) &&
+                data.TryGetPropertyCI("elements", out var elements) &&
+                elements.ValueKind == JsonValueKind.Array)
+            {
+                return elements.EnumerateArray().ToList();
+            }
+            return new List<JsonElement>();
+        }
+
+        /// <summary>
+        /// Extracts data.metadata.totalFound from a serialized SearchElements response (-1 if absent).
+        /// </summary>
+        private static int GetTotalFound(JsonElement response)
+        {
+            if (response.TryGetPropertyCI("data", out var data) &&
+                data.TryGetPropertyCI("metadata", out var metadata) &&
+                metadata.TryGetPropertyCI("totalFound", out var totalFound) &&
+                totalFound.ValueKind == JsonValueKind.Number)
+            {
+                return totalFound.GetInt32();
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Reads a string property (case-insensitive) from a JSON element, or "" when missing.
+        /// </summary>
+        private static string GetStr(JsonElement element, string property)
+        {
+            if (element.TryGetPropertyCI(property, out var value) && value.ValueKind == JsonValueKind.String)
+            {
+                return value.GetString() ?? string.Empty;
+            }
+            return string.Empty;
         }
 
         #endregion

--- a/UiAutomationMcp.Tests/UnitTests/Helpers/SearchTextMatcherTests.cs
+++ b/UiAutomationMcp.Tests/UnitTests/Helpers/SearchTextMatcherTests.cs
@@ -1,0 +1,133 @@
+using UIAutomationMCP.Subprocess.Worker.Helpers;
+using Xunit;
+
+namespace UiAutomationMcp.Tests.UnitTests.Helpers
+{
+    /// <summary>
+    /// Unit tests for <see cref="SearchTextMatcher"/> - the cross-property substring/fuzzy
+    /// matching used by SearchElements to filter found elements by searchText.
+    /// </summary>
+    public class SearchTextMatcherTests
+    {
+        #region Substring (non-fuzzy) matching
+
+        [Theory]
+        [InlineData("RichEditBox", "RichEditBox")]   // exact
+        [InlineData("RichEditBox", "richeditbox")]   // case-insensitive
+        [InlineData("RichEditBox", "EditBox")]       // substring
+        [InlineData("RichEditBox", "Edit")]          // substring
+        [InlineData("MyRichEditBoxControl", "RichEditBox")]
+        public void IsMatch_NonFuzzy_MatchingSubstring_ReturnsTrue(string candidate, string searchText)
+        {
+            Assert.True(SearchTextMatcher.IsMatch(candidate, searchText, fuzzyMatch: false));
+        }
+
+        [Theory]
+        [InlineData("WinUI 3 Gallery", "RichEditBox")]
+        [InlineData("Minimize", "RichEditBox")]
+        [InlineData("Home", "Button")]
+        [InlineData("RichEditBox", "Rich Edit Box")] // spaces break the plain substring match
+        public void IsMatch_NonFuzzy_NonMatching_ReturnsFalse(string candidate, string searchText)
+        {
+            Assert.False(SearchTextMatcher.IsMatch(candidate, searchText, fuzzyMatch: false));
+        }
+
+        #endregion
+
+        #region Fuzzy (normalized) matching
+
+        [Theory]
+        [InlineData("Rich Edit Box", "RichEditBox")]
+        [InlineData("rich-edit-box", "RichEditBox")]
+        [InlineData("rich_edit_box", "richeditbox")]
+        [InlineData("Rich.Edit.Box", "edit box")]
+        [InlineData("RichEditBox", "rich edit box")]
+        public void IsMatch_Fuzzy_NormalizedMatch_ReturnsTrue(string candidate, string searchText)
+        {
+            Assert.True(SearchTextMatcher.IsMatch(candidate, searchText, fuzzyMatch: true));
+        }
+
+        [Theory]
+        [InlineData("WinUI 3 Gallery", "RichEditBox")]
+        [InlineData("Home", "RichEditBox")]
+        public void IsMatch_Fuzzy_NonMatching_ReturnsFalse(string candidate, string searchText)
+        {
+            Assert.False(SearchTextMatcher.IsMatch(candidate, searchText, fuzzyMatch: true));
+        }
+
+        [Fact]
+        public void IsMatch_Fuzzy_SearchTextWithoutAlphanumerics_FallsBackToSubstring()
+        {
+            // "!!!" normalizes to empty; should not match everything.
+            Assert.False(SearchTextMatcher.IsMatch("RichEditBox", "!!!", fuzzyMatch: true));
+            Assert.True(SearchTextMatcher.IsMatch("a!!!b", "!!!", fuzzyMatch: true));
+        }
+
+        #endregion
+
+        #region Edge cases
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void IsMatch_EmptyOrNullSearchText_ReturnsTrue(string? searchText)
+        {
+            // An empty search text imposes no filter.
+            Assert.True(SearchTextMatcher.IsMatch("anything", searchText, fuzzyMatch: false));
+            Assert.True(SearchTextMatcher.IsMatch("anything", searchText, fuzzyMatch: true));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void IsMatch_EmptyOrNullCandidate_WithSearchText_ReturnsFalse(string? candidate)
+        {
+            Assert.False(SearchTextMatcher.IsMatch(candidate, "Button", fuzzyMatch: false));
+            Assert.False(SearchTextMatcher.IsMatch(candidate, "Button", fuzzyMatch: true));
+        }
+
+        #endregion
+
+        #region Cross-property matching (IsMatchAny)
+
+        [Fact]
+        public void IsMatchAny_MatchesOnAnyCandidate()
+        {
+            // Matches on Name
+            Assert.True(SearchTextMatcher.IsMatchAny("Submit", fuzzyMatch: false,
+                "Submit Button", "OkButtonId", "Button"));
+
+            // Matches on AutomationId
+            Assert.True(SearchTextMatcher.IsMatchAny("OkButtonId", fuzzyMatch: false,
+                "Cancel", "OkButtonId", "Button"));
+
+            // Matches on ClassName
+            Assert.True(SearchTextMatcher.IsMatchAny("TextBlock", fuzzyMatch: false,
+                "Cancel", "CancelId", "TextBlock"));
+        }
+
+        [Fact]
+        public void IsMatchAny_NoCandidateMatches_ReturnsFalse()
+        {
+            Assert.False(SearchTextMatcher.IsMatchAny("RichEditBox", fuzzyMatch: false,
+                "WinUI 3 Gallery", "HomeItem", "NavigationViewItem"));
+        }
+
+        [Fact]
+        public void IsMatchAny_IgnoresNullAndEmptyCandidates()
+        {
+            Assert.True(SearchTextMatcher.IsMatchAny("Button", fuzzyMatch: false,
+                null, "", "MyButton"));
+            Assert.False(SearchTextMatcher.IsMatchAny("Button", fuzzyMatch: false,
+                null, "", null));
+        }
+
+        [Fact]
+        public void IsMatchAny_EmptySearchText_ReturnsTrue()
+        {
+            Assert.True(SearchTextMatcher.IsMatchAny("", fuzzyMatch: false, "a", "b"));
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Problem

`SearchElements` advertises a headline `searchText` parameter (*"Cross-property search text (searches Name, AutomationId, ClassName)"*) and a `fuzzyMatch` parameter, but **both were silently ignored** by the worker. Any `searchText`/`fuzzyMatch` query returned the entire element tree (capped at `maxResults`) instead of filtered results.

Root cause: the params were mapped onto `SearchElementsRequest`, but `SearchElementsOperation` never wired them into `ElementSearchCriteria`, and UIA `PropertyCondition` cannot express substring/fuzzy matches anyway.

Empirically (WinUI 3 Gallery 2.9.3): `SearchElements(searchText:"RichEditBox")` returned 50 irrelevant elements ("WinUI 3 Gallery", "Minimize", "Home", …) with `totalFound` identical (3130) across totally different search texts.

## Fix

In-process filtering in `SearchElementsOperation.PerformSearchAsync`, applied **after** `FindElementsWithOptimalMethod` but **before** sort / `MaxResults` / `totalFound`, so metadata counts reflect the filtered set.

- **New `SearchTextMatcher` helper** — case-insensitive substring match; `fuzzyMatch` normalizes both sides (strips non-alphanumerics + lowercases) so `"RichEditBox"` matches `"Rich Edit Box"`, `"rich-edit-box"`, etc.
- **`FilterBySearchText`** reads Name/AutomationId/ClassName (cached-first, with a current-value fallback for elements returned outside the `CacheRequest` scope, e.g. `ListSearchOptimizer`).

Chose to filter in the operation rather than extend `ElementFinderService.BuildSearchCondition`, keeping UIA condition-building free of substring logic.

## Tests

- **25 `SearchTextMatcher` unit tests** — substring, fuzzy normalization, empty/null edge cases, cross-property, punctuation-only fallback. All pass.
- **E2E `Test_03b_SearchElements_SearchText_ActuallyFilters`** — asserts a nonsense token returns 0 (the killer assertion reproducing the bug), a real token returns only matching elements, and filtering reduces the count.

### Verified on live WinUI 3 Gallery 2.9.3

| Search | totalFound |
|---|---|
| unfiltered | 2642 |
| nonsense `"ZZ_NoSuchElement_QWERTY_123"` | **0** (was: whole tree) |
| real token `'スタート'` | **2** (all returned elements matched) |

## Out of scope

`className` / `visibleOnly` / `enabledOnly` are *also* not wired into the worker (analogous gap) — tracked separately, since `visibleOnly`'s default of `true` implies a behavior change that needs its own verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)