### PR TITLE
chore: re-enable test project in solution and run Unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
     - name: Run tests
       run: |
         dotnet test --configuration Release --no-build --verbosity detailed `
+          --filter "Category=Unit" `
           --logger "trx;LogFileName=test-results.trx" `
           --logger "console;verbosity=detailed" `
           --collect:"XPlat Code Coverage" `

--- a/UIAutomationMCP.sln
+++ b/UIAutomationMCP.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UIAutomationMCP.Subprocess.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UIAutomationMCP.Models", "UIAutomationMCP.Models\UIAutomationMCP.Models.csproj", "{34567890-3456-3456-3456-345678901234}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UiAutomationMcp.Tests", "UiAutomationMcp.Tests\UiAutomationMcp.Tests.csproj", "{1E91B6A3-5683-453D-AEFA-827565A031DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,18 @@ Global
 		{34567890-3456-3456-3456-345678901234}.Release|x64.Build.0 = Release|Any CPU
 		{34567890-3456-3456-3456-345678901234}.Release|x86.ActiveCfg = Release|Any CPU
 		{34567890-3456-3456-3456-345678901234}.Release|x86.Build.0 = Release|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Release|x64.Build.0 = Release|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{1E91B6A3-5683-453D-AEFA-827565A031DC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UiAutomationMcp.Tests/E2E/NewPatternsE2ETests.cs
+++ b/UiAutomationMcp.Tests/E2E/NewPatternsE2ETests.cs
@@ -10,6 +10,7 @@ namespace UIAutomationMCP.Tests.E2E;
 /// These tests require real Windows applications to be available.
 /// </summary>
 [Collection("UIAutomation")]
+[Trait("Category", "E2E")]
 public class NewPatternsE2ETests : BaseE2ETest
 {
     private readonly ITestOutputHelper _output;

--- a/UiAutomationMcp.Tests/Integration/SynchronizedInputPatternIntegrationTests.cs
+++ b/UiAutomationMcp.Tests/Integration/SynchronizedInputPatternIntegrationTests.cs
@@ -11,6 +11,7 @@ using UIAutomationMCP.Models.Abstractions;
 
 namespace UiAutomationMcp.Tests.Integration;
 
+[Trait("Category", "Integration")]
 public class SynchronizedInputPatternIntegrationTests : IDisposable
 {
     private readonly ServiceProvider _serviceProvider;
@@ -172,9 +173,6 @@ public class SynchronizedInputPatternIntegrationTests : IDisposable
     public async Task WorkerProcessLifecycle_MultipleOperations_ShouldHandleCorrectly()
     {
         // Arrange
-        var startCallCount = 0;
-        var cancelCallCount = 0;
-
         _mockSubprocessExecutor
             .Setup(x => x.ExecuteWorkerOperationAsync<StartSynchronizedInputRequest, ElementSearchResult>(
                 "StartSynchronizedInput",

--- a/UiAutomationMcp.Tests/Models/SharedModelsTests.cs
+++ b/UiAutomationMcp.Tests/Models/SharedModelsTests.cs
@@ -8,6 +8,7 @@ namespace UiAutomationMcp.Tests.Models
     /// <summary>
     /// SharedModels                  ///                                                                     /// </summary>
     [Collection("UIAutomationTestCollection")]
+    [Trait("Category", "Unit")]
     public class SharedModelsTests
     {
         [Fact]

--- a/UiAutomationMcp.Tests/Requests/TypedRequestTests.cs
+++ b/UiAutomationMcp.Tests/Requests/TypedRequestTests.cs
@@ -8,6 +8,7 @@ namespace UiAutomationMcp.Tests.Requests
     ///                               (     Tools Level Serialization       )
     /// </summary>
     [Collection("UIAutomationTestCollection")]
+    [Trait("Category", "Unit")]
     public class TypedRequestTests
     {
         [Fact]

--- a/UiAutomationMcp.Tests/UnitTests/Helpers/CacheRequestHelperTests.cs
+++ b/UiAutomationMcp.Tests/UnitTests/Helpers/CacheRequestHelperTests.cs
@@ -7,6 +7,7 @@ namespace UiAutomationMcp.Tests.UnitTests.Helpers
     /// <summary>
     /// Unit tests for CacheRequestHelper to verify cache optimization functionality
     /// </summary>
+    [Trait("Category", "Unit")]
     public class CacheRequestHelperTests
     {
         [Fact]

--- a/UiAutomationMcp.Tests/UnitTests/Helpers/SearchTextMatcherTests.cs
+++ b/UiAutomationMcp.Tests/UnitTests/Helpers/SearchTextMatcherTests.cs
@@ -7,6 +7,7 @@ namespace UiAutomationMcp.Tests.UnitTests.Helpers
     /// Unit tests for <see cref="SearchTextMatcher"/> - the cross-property substring/fuzzy
     /// matching used by SearchElements to filter found elements by searchText.
     /// </summary>
+    [Trait("Category", "Unit")]
     public class SearchTextMatcherTests
     {
         #region Substring (non-fuzzy) matching

--- a/UiAutomationMcp.Tests/UnitTests/Helpers/UIAutomationEnvironmentTests.cs
+++ b/UiAutomationMcp.Tests/UnitTests/Helpers/UIAutomationEnvironmentTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace UiAutomationMcp.Tests.UnitTests.Helpers
 {
+    [Trait("Category", "Unit")]
     public class UIAutomationEnvironmentTests
     {
         [Fact]
@@ -56,6 +57,7 @@ namespace UiAutomationMcp.Tests.UnitTests.Helpers
     /// <summary>
     /// Performance and stress tests for UIAutomationEnvironment
     /// </summary>
+    [Trait("Category", "Unit")]
     public class UIAutomationEnvironmentPerformanceTests
     {
         [Fact]

--- a/UiAutomationMcp.Tests/UnitTests/Options/PerformanceOptionsTests.cs
+++ b/UiAutomationMcp.Tests/UnitTests/Options/PerformanceOptionsTests.cs
@@ -6,6 +6,7 @@ namespace UiAutomationMcp.Tests.UnitTests.Options
     /// <summary>
     /// Unit tests for PerformanceOptions configuration
     /// </summary>
+    [Trait("Category", "Unit")]
     public class PerformanceOptionsTests
     {
         [Fact]


### PR DESCRIPTION
## Summary

Fixes #18. The test project was excluded from `UIAutomationMCP.sln` (#17) to unblock CI and never re-added. As a result `ci.yml`'s solution-level `dotnet test` discovered **zero** of these tests — the only functional CI coverage was the black-box checks in `staging-test.yml`.

This re-adds the test project to the solution and wires the **headless-safe Unit subset** into CI.

## Changes

- **Add `UiAutomationMcp.Tests` back to `UIAutomationMCP.sln`** — the `build` job now compiles it and the `test` job can run it via `--no-build`.
- **Gate the CI test job with `--filter "Category=Unit"`** — E2E (needs WinUI 3 Gallery / a live desktop) and subprocess Integration stay out of headless CI. Positive filter, so untagged tests never leak in.
- **Tag 8 previously-untagged test classes** with `[Trait("Category", ...)]`:
  - 6 pure-logic classes → `Unit` (otherwise a `Category=Unit` filter would silently skip them): `CacheRequestHelperTests`, `SearchTextMatcherTests`, `UIAutomationEnvironmentTests` (+`…PerformanceTests`), `PerformanceOptionsTests`, `SharedModelsTests`, `TypedRequestTests`.
  - `SynchronizedInputPatternIntegrationTests` → `Integration`, `NewPatternsE2ETests` → `E2E` (hygiene / prevents negative-filter leaks later).
- **Remove two unused locals** (`CS0219`) in `SynchronizedInputPatternIntegrationTests` so the `/warnaserror` code-quality build stays clean.

## Verification (local)

- `dotnet build UIAutomationMCP.sln -c Release -p:TreatWarningsAsErrors=true` → **0 warnings, 0 errors**.
- `dotnet test UIAutomationMCP.sln -c Release --filter "Category=Unit"` → **541 passed, 0 failed (~6s)**.

## Out of scope

- Integration (96) and E2E (76) remain local/manual (live desktop & Store-app dependencies). Bringing Integration into CI can be a follow-up.

Closes #18