### PR TITLE
fix: move flaky wall-clock perf test out of CI Unit gate

### DIFF
--- a/UiAutomationMcp.Tests/UnitTests/Helpers/UIAutomationEnvironmentTests.cs
+++ b/UiAutomationMcp.Tests/UnitTests/Helpers/UIAutomationEnvironmentTests.cs
@@ -55,9 +55,12 @@ namespace UiAutomationMcp.Tests.UnitTests.Helpers
     }
 
     /// <summary>
-    /// Performance and stress tests for UIAutomationEnvironment
+    /// Performance and stress tests for UIAutomationEnvironment.
+    /// Tagged "Performance" (not "Unit") because the assertions are wall-clock timing
+    /// based and therefore non-deterministic on shared CI runners — excluded from the
+    /// CI Category=Unit gate; run locally with --filter "Category=Performance".
     /// </summary>
-    [Trait("Category", "Unit")]
+    [Trait("Category", "Performance")]
     public class UIAutomationEnvironmentPerformanceTests
     {
         [Fact]


### PR DESCRIPTION
## Problem

After #28 merged, the **main** CI went red. The `Run Tests` job failed on a single test:

```
Failed IsAvailable_MultipleAccess_IsEfficient
  100 calls to IsAvailable took 524.5417ms, expected < 500ms
```

`IsAvailable_MultipleAccess_IsEfficient` is a **wall-clock timing assertion** (100 property accesses must finish under 500 ms). It is machine-speed dependent and non-deterministic on shared GitHub runners — it happened to pass on the PR #28 runner but failed on the post-merge main runner (524 ms vs the 500 ms threshold). #28 pulled it into the CI gate by tagging its class `Unit`.

## Fix

Retag `UIAutomationEnvironmentPerformanceTests` from `Unit` → `Performance`:

- Excluded from the CI `--filter "Category=Unit"` gate → CI is deterministic again.
- Still categorized (not untagged) and runnable locally via `--filter "Category=Performance"`.
- Semantically correct — the class doc comment already calls it a "Performance and stress test".
- The deterministic `UIAutomationEnvironmentTests` class stays `Unit`.

## Verification (local)

- `dotnet test --filter "Category=Unit"` → **540 passed** (flaky test excluded).
- `dotnet test --filter "Category=Performance"` → **1** (the perf test).